### PR TITLE
Added kape flag to separate out parsed data

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,11 @@ With the following arguments meaning:
   -o, --old               Extract the old bitmap data found in the BMCache file.
   -b, --bitmap            Provide a collage bitmap aggregating all the tiles.
   -w WIDTH, --width WIDTH Specify the number of tiles per line of the aggregated bitmap (default=64).
+  -k, --kape            Use this option to split out the different inputs into separate folders
 ```
 ## Changelog
 ```
+15/05/2023    3.03  Added KAPE output to split output into seperate folders
 02/03/2023		3.02	Added destination folder existence check beforehand.
 01/03/2023		3.01	Fixed old Bitmaps storage and export.
 10/02/2022		3.00	Now performing tile decompression.

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ With the following arguments meaning:
 ```
 ## Changelog
 ```
-15/05/2023    3.03  Added KAPE output to split output into seperate folders
+15/05/2023		3.03  Added KAPE output to split output into seperate folders
 02/03/2023		3.02	Added destination folder existence check beforehand.
 01/03/2023		3.01	Fixed old Bitmaps storage and export.
 10/02/2022		3.00	Now performing tile decompression.

--- a/bmc-tools.py
+++ b/bmc-tools.py
@@ -383,6 +383,7 @@ if __name__ == "__main__":
 	prs.add_argument("-o", "--old", help="Extract the old bitmap data found in the BMCache file.", action="store_true", default=False)
 	prs.add_argument("-b", "--bitmap", help="Provide a big bitmap aggregating all the tiles.", action="store_true", default=False)
 	prs.add_argument("-w", "--width", help="Specify the number of tiles per line of the aggregated bitmap (default=64).", type=int, default=64)
+	prs.add_argument('-k', "--kape", help="Use this option to split out the different inputs into separate folders", action="store_true", default="False")
 	args = prs.parse_args(sys.argv[1:])
 	bmcc = BMCContainer(verbose=args.verbose, count=args.count, old=args.old, big=args.bitmap, width=args.width)
 	src_files = []
@@ -407,8 +408,19 @@ if __name__ == "__main__":
 		sys.stdout.write("[+++] Processing a single file: '%s'.%s" % (args.src, os.linesep))
 		src_files.append(args.src)
 	for src in src_files:
+		sys.stdout.write("[+++] Processing a file: '%s'.%s" % (src, os.linesep)) 		
 		if bmcc.b_import(src):
+			destination = args.dest
+			if (args.kape):
+				destination = src.replace("\\","_").replace("//","_").replace(":","_")
+				destination = destination.replace("_AppData_Local_Microsoft_Terminal Server Client_Cache","").replace("__users_","")[1:]
+				destination = args.dest + "\\" + destination
+			if not os.path.exists(destination):
+				os.makedirs(destination)
+			
 			bmcc.b_process()
-			bmcc.b_export(args.dest)
+			bmcc.b_export(destination)
 			bmcc.b_flush()
+		
+		
 	del bmcc

--- a/bmc-tools.py
+++ b/bmc-tools.py
@@ -385,6 +385,7 @@ if __name__ == "__main__":
 	prs.add_argument("-w", "--width", help="Specify the number of tiles per line of the aggregated bitmap (default=64).", type=int, default=64)
 	prs.add_argument('-k', "--kape", help="Use this option to split out the different inputs into separate folders", action="store_true", default="False")
 	args = prs.parse_args(sys.argv[1:])
+
 	bmcc = BMCContainer(verbose=args.verbose, count=args.count, old=args.old, big=args.bitmap, width=args.width)
 	src_files = []
 	if not os.path.isdir(args.dest):
@@ -411,12 +412,11 @@ if __name__ == "__main__":
 		sys.stdout.write("[+++] Processing a file: '%s'.%s" % (src, os.linesep)) 		
 		if bmcc.b_import(src):
 			destination = args.dest
-			if (args.kape):
-				destination = src.replace("\\","_").replace("//","_").replace(":","_")
-				destination = destination.replace("_AppData_Local_Microsoft_Terminal Server Client_Cache","").replace("__users_","")[1:]
+			if (args.kape == True):
+				destination = src.replace("\\","_").replace("//","_").replace(":","_").replace("_AppData_Local_Microsoft_Terminal Server Client_Cache","")
 				destination = args.dest + "\\" + destination
-			if not os.path.exists(destination):
-				os.makedirs(destination)
+				if not os.path.exists(destination):
+					os.makedirs(destination)
 			
 			bmcc.b_process()
 			bmcc.b_export(destination)

--- a/bmc-tools.py
+++ b/bmc-tools.py
@@ -375,7 +375,7 @@ class BMCContainer():
 		return True
 
 if __name__ == "__main__":
-	prs = argparse.ArgumentParser(description="RDP Bitmap Cache parser (v. 3.02, 2023/03/02)")
+	prs = argparse.ArgumentParser(description="RDP Bitmap Cache parser (v. 3.03, 2023/05/15)")
 	prs.add_argument("-s", "--src", help="Specify the BMCache file or directory to process.", required=True)
 	prs.add_argument("-d", "--dest", help="Specify the directory where to store the extracted bitmaps.", required=True)
 	prs.add_argument("-c", "--count", help="Only extract the given number of bitmaps.", type=int, default=-1)


### PR DESCRIPTION
I added some extra code to the bottom so that when you run this tool over a whole drive with KAPE you end up with a new folder for each of the parsed files. This will mean that people won't attribute a RDP cache activity from one user with that of another.

By default the flag is set to false