### PR TITLE
Corrupt cache file would lead to endless loop

### DIFF
--- a/bmc-tools.py
+++ b/bmc-tools.py
@@ -339,7 +339,7 @@ class BMCContainer():
 			for i in range(len(self.bmps)):
 				if self.pal:
 					self.bmps[i] = self.bmps[i][len(self.PALETTE):]
-				while len(self.bmps[i]) != 64*64*len(pad):
+				while len(self.bmps[i]) < 64*64*len(pad):
 					self.bmps[i]+=pad*64
 			w = 64*len(self.bmps)
 			h = 64


### PR DESCRIPTION
When padding the buffer doesn't lead to the exact size (e.g. bigger) it will keep appending.

A corrupt file still wouldn't really work, but at least the tool would terminate